### PR TITLE
Add e-conomic API client and `list_customers` MCP tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "e-conomic-mcp-server",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "zod": "^3.23.8"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,113 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+const server = new McpServer({
+  name: "e-conomic-mcp-server",
+  version: "0.1.0",
+});
+
+const ECONOMIC_BASE_URL =
+  process.env.ECONOMIC_BASE_URL?.replace(/\/$/, "") ??
+  "https://restapi.e-conomic.com";
+const ECONOMIC_APP_SECRET_TOKEN = process.env.ECONOMIC_APP_SECRET_TOKEN;
+const ECONOMIC_AGREEMENT_GRANT_TOKEN = process.env.ECONOMIC_AGREEMENT_GRANT_TOKEN;
+
+const defaultHeaders = () => {
+  if (!ECONOMIC_APP_SECRET_TOKEN || !ECONOMIC_AGREEMENT_GRANT_TOKEN) {
+    throw new Error(
+      "Missing ECONOMIC_APP_SECRET_TOKEN or ECONOMIC_AGREEMENT_GRANT_TOKEN environment variables."
+    );
+  }
+
+  return {
+    "Content-Type": "application/json",
+    "X-AppSecretToken": ECONOMIC_APP_SECRET_TOKEN,
+    "X-AgreementGrantToken": ECONOMIC_AGREEMENT_GRANT_TOKEN,
+  };
+};
+
+const economicRequest = async (path, { method = "GET", body } = {}) => {
+  const response = await fetch(`${ECONOMIC_BASE_URL}${path}`, {
+    method,
+    headers: defaultHeaders(),
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(
+      `e-conomic API request failed (${response.status}): ${errorText}`
+    );
+  }
+
+  return response.json();
+};
+
+server.registerTool(
+  "hello",
+  {
+    title: "Hello",
+    description: "Return a friendly greeting.",
+    inputSchema: z.object({
+      name: z.string().optional().describe("Name to greet"),
+    }),
+  },
+  async ({ name }) => {
+    const target = name?.trim() ? name.trim() : "world";
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Hello, ${target}!`,
+        },
+      ],
+    };
+  }
+);
+
+server.registerTool(
+  "list_customers",
+  {
+    title: "List customers",
+    description: "Fetch a page of customers from the e-conomic API.",
+    inputSchema: z.object({
+      pageSize: z
+        .number()
+        .int()
+        .min(1)
+        .max(1000)
+        .optional()
+        .describe("Number of customers per page (default 100)."),
+      page: z
+        .number()
+        .int()
+        .min(1)
+        .optional()
+        .describe("Page number to fetch (default 1)."),
+    }),
+  },
+  async ({ pageSize, page }) => {
+    const resolvedPageSize = pageSize ?? 100;
+    const resolvedPage = page ?? 1;
+    const skipPages = resolvedPage - 1;
+    const query = new URLSearchParams({
+      pagesize: String(resolvedPageSize),
+      skippages: String(skipPages),
+    });
+
+    const data = await economicRequest(`/customers?${query.toString()}`);
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(data, null, 2),
+        },
+      ],
+    };
+  }
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);


### PR DESCRIPTION
### Motivation
- Provide authenticated helpers to call the e-conomic REST API from the MCP server using environment-provided tokens.  
- Expose a simple tool that allows an MCP client to list customers with pagination.  
- Return API payloads in a format the MCP transport can deliver as text content.  
- Keep configuration flexible via `ECONOMIC_BASE_URL`, `ECONOMIC_APP_SECRET_TOKEN`, and `ECONOMIC_AGREEMENT_GRANT_TOKEN` environment variables.

### Description
- Added environment-backed configuration and constants `ECONOMIC_BASE_URL`, `ECONOMIC_APP_SECRET_TOKEN`, and `ECONOMIC_AGREEMENT_GRANT_TOKEN` to `server.js`.  
- Implemented `defaultHeaders` and `economicRequest` helpers that set required headers and perform `fetch` calls, throwing on non-OK responses.  
- Registered a `list_customers` tool with a `zod` `inputSchema` for `pageSize` and `page`, which builds `pagesize` and `skippages` query parameters and returns the API response as formatted JSON text.  
- Included existing MCP server entrypoint and `hello` tool, and added `package.json` with `start` script and dependencies on `@modelcontextprotocol/sdk` and `zod`.

### Testing
- No automated tests were executed for this change.  
- A prior attempt to run `npm install @modelcontextprotocol/sdk zod` failed with a `403 Forbidden` from the registry, preventing dependency installation and automated test runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c77923fb4833295e544cc1c64b43a)